### PR TITLE
Bump version for added windows support

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,6 +1,6 @@
 {
   "name": "@udibo/react-app",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "exports": {
     ".": "./mod.tsx",
     "./build": "./build.ts",
@@ -94,6 +94,7 @@
     "react-helmet-async": "npm:react-helmet-async@2",
     "serialize-javascript": "npm:serialize-javascript@6",
     "@testing-library/react": "npm:@testing-library/react@16",
-    "global-jsdom": "npm:global-jsdom@24"
+    "global-jsdom": "npm:global-jsdom@24",
+    "@tanstack/query": "npm:@tanstack/query@5"
   }
 }

--- a/example/deno.jsonc
+++ b/example/deno.jsonc
@@ -66,6 +66,7 @@
     "react-helmet-async": "npm:react-helmet-async@2",
     "serialize-javascript": "npm:serialize-javascript@6",
     "@testing-library/react": "npm:@testing-library/react@16",
-    "global-jsdom": "npm:global-jsdom@24"
+    "global-jsdom": "npm:global-jsdom@24",
+    "@tanstack/query": "npm:@tanstack/query@5"
   }
 }


### PR DESCRIPTION
Forgot to bump version when fixing the build script for windows.

Also adding @tanstack/react to the import map as I plan on updating the example here to use it and I want to test if it will show as a dependency in jsr even though it's not used by any entrypoint. It will only be used by the example which is excluded from jsr.