### PR TITLE
Fix version references and ignore .deno.lock.poll file

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -7,7 +7,7 @@
  * ```jsonc
  * "tasks": {
  *   // Builds the application.
- *   "build": "deno run -A --config=deno.jsonc jsr:@udibo/react-app@0.22/build",
+ *   "build": "deno run -A --config=deno.jsonc jsr:@udibo/react-app@0.24.1/build",
  *   // Builds the application in development mode.
  *   "build-dev": "export APP_ENV=development NODE_ENV=development && deno task build",
  *   // Builds the application in production mode.

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,6 +1,6 @@
 {
   "name": "@udibo/react-app",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "exports": {
     ".": "./mod.tsx",
     "./build": "./build.ts",

--- a/dev.ts
+++ b/dev.ts
@@ -8,7 +8,7 @@
  * ```jsonc
  * "tasks": {
       // Builds and runs the application in development mode, with hot reloading.
- *    "dev": "export APP_ENV=development NODE_ENV=development && deno run -A --config=deno.jsonc jsr:@udibo/react-app@0.22/dev",
+ *    "dev": "export APP_ENV=development NODE_ENV=development && deno run -A --config=deno.jsonc jsr:@udibo/react-app@0.24.1/dev",
  * }
  * ```
  *
@@ -270,7 +270,8 @@ export function startDev(options: DevOptions = {}): void {
   artifacts.add(path.resolve(routesUrl, "./_main.ts"));
 
   function isBuildArtifact(pathname: string) {
-    return pathname.startsWith(buildDir) || artifacts.has(pathname);
+    return pathname.startsWith(buildDir) || artifacts.has(pathname) ||
+      pathname.endsWith("/node_modules/.deno/.deno.lock.poll");
   }
 
   const shouldBuild = isCustomBuildArtifact

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,7 +21,9 @@ To learn more about using the default tasks, see the
 
 If you need to customize your build options to be different from the default,
 follow the instructions for adding the [build.ts](getting-started.md#buildts)
-and [dev.ts](getting-started.md#devts) files in the getting started guide.
+and [dev.ts](getting-started.md#devts) files in the getting started guide. Then
+for more information on the build configuration options available, see the
+[build](#build) section of this guide.
 
 You can add any tasks that you want to your configuration, for more information
 on how to do so, see Deno's

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -103,13 +103,13 @@ Node.js-like environment.
 {
   "tasks": {
     // Builds the application.
-    "build": "deno run -A --config=deno.jsonc jsr:@udibo/react-app@0.24/build",
+    "build": "deno run -A --config=deno.jsonc jsr:@udibo/react-app@0.24.1/build",
     // Builds the application in development mode.
     "build-dev": "export APP_ENV=development NODE_ENV=development && deno task build",
     // Builds the application in production mode.
     "build-prod": "export APP_ENV=production NODE_ENV=production && deno task build",
     // Builds and runs the application in development mode, with hot reloading.
-    "dev": "export APP_ENV=development NODE_ENV=development && deno run -A --config=deno.jsonc jsr:@udibo/react-app@0.24/dev",
+    "dev": "export APP_ENV=development NODE_ENV=development && deno run -A --config=deno.jsonc jsr:@udibo/react-app@0.24.1/dev",
     // Runs the application. Requires the application to be built first.
     "run": "deno run -A ./main.ts",
     // Runs the application in development mode. Requires the application to be built first.
@@ -141,7 +141,7 @@ Node.js-like environment.
   "imports": {
     "/": "./",
     "./": "./",
-    "@udibo/react-app": "jsr:@udibo/react-app@0.22",
+    "@udibo/react-app": "jsr:@udibo/react-app@0.24.1",
     "@std/assert": "jsr:@std/assert@1",
     "@std/log": "jsr:@std/log@0",
     "@std/path": "jsr:@std/path@1",
@@ -549,13 +549,13 @@ on:
 jobs:
   ci:
     name: CI
-    uses: udibo/react-app/.github/workflows/ci.yml@0.24.0
+    uses: udibo/react-app/.github/workflows/ci.yml@0.24.1
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   cd:
     name: CD
     needs: ci
-    uses: udibo/react-app/.github/workflows/deploy.yml@0.24.0
+    uses: udibo/react-app/.github/workflows/deploy.yml@0.24.1
     with:
       project: udibo-react-app-example
 ```


### PR DESCRIPTION
Noticed some version references were stale. Also fixed an issue where rebuilds are happening repeatedly on the dev server due to an internal deno file that repeatedly gets updated.