### PR TITLE
Fix github deploy workflow's default app-directory

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ on:
       app-directory:
         description: The directory containing the application to deploy
         type: string
-        default: ''
+        default: '.'
       entrypoint:
         description: The entrypoint file for running your application
         type: string

--- a/build.ts
+++ b/build.ts
@@ -7,7 +7,7 @@
  * ```jsonc
  * "tasks": {
  *   // Builds the application.
- *   "build": "deno run -A --config=deno.jsonc jsr:@udibo/react-app@0.24.1/build",
+ *   "build": "deno run -A --config=deno.jsonc jsr:@udibo/react-app@0.24.2/build",
  *   // Builds the application in development mode.
  *   "build-dev": "export APP_ENV=development NODE_ENV=development && deno task build",
  *   // Builds the application in production mode.

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,6 +1,6 @@
 {
   "name": "@udibo/react-app",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "exports": {
     ".": "./mod.tsx",
     "./build": "./build.ts",

--- a/dev.ts
+++ b/dev.ts
@@ -8,7 +8,7 @@
  * ```jsonc
  * "tasks": {
       // Builds and runs the application in development mode, with hot reloading.
- *    "dev": "export APP_ENV=development NODE_ENV=development && deno run -A --config=deno.jsonc jsr:@udibo/react-app@0.24.1/dev",
+ *    "dev": "export APP_ENV=development NODE_ENV=development && deno run -A --config=deno.jsonc jsr:@udibo/react-app@0.24.2/dev",
  * }
  * ```
  *

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -103,13 +103,13 @@ Node.js-like environment.
 {
   "tasks": {
     // Builds the application.
-    "build": "deno run -A --config=deno.jsonc jsr:@udibo/react-app@0.24.1/build",
+    "build": "deno run -A --config=deno.jsonc jsr:@udibo/react-app@0.24.2/build",
     // Builds the application in development mode.
     "build-dev": "export APP_ENV=development NODE_ENV=development && deno task build",
     // Builds the application in production mode.
     "build-prod": "export APP_ENV=production NODE_ENV=production && deno task build",
     // Builds and runs the application in development mode, with hot reloading.
-    "dev": "export APP_ENV=development NODE_ENV=development && deno run -A --config=deno.jsonc jsr:@udibo/react-app@0.24.1/dev",
+    "dev": "export APP_ENV=development NODE_ENV=development && deno run -A --config=deno.jsonc jsr:@udibo/react-app@0.24.2/dev",
     // Runs the application. Requires the application to be built first.
     "run": "deno run -A ./main.ts",
     // Runs the application in development mode. Requires the application to be built first.
@@ -141,7 +141,7 @@ Node.js-like environment.
   "imports": {
     "/": "./",
     "./": "./",
-    "@udibo/react-app": "jsr:@udibo/react-app@0.24.1",
+    "@udibo/react-app": "jsr:@udibo/react-app@0.24.2",
     "@std/assert": "jsr:@std/assert@1",
     "@std/log": "jsr:@std/log@0",
     "@std/path": "jsr:@std/path@1",
@@ -549,13 +549,13 @@ on:
 jobs:
   ci:
     name: CI
-    uses: udibo/react-app/.github/workflows/ci.yml@0.24.1
+    uses: udibo/react-app/.github/workflows/ci.yml@0.24.2
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   cd:
     name: CD
     needs: ci
-    uses: udibo/react-app/.github/workflows/deploy.yml@0.24.1
+    uses: udibo/react-app/.github/workflows/deploy.yml@0.24.2
     with:
       project: udibo-react-app-example
 ```


### PR DESCRIPTION
Without it, the default entrypoint would be `/main.ts` and that fails because the script is running from the `file:///src` directory. The default needs to be the current directory that the workflow is running in, the entrypoint should be within the src directory.